### PR TITLE
讓 DrawComponent 有 Layer 的概念

### DIFF
--- a/src/main/java/us/dontcareabout/gxt/client/draw/LSprite.java
+++ b/src/main/java/us/dontcareabout/gxt/client/draw/LSprite.java
@@ -5,6 +5,7 @@ import com.sencha.gxt.chart.client.draw.sprite.Sprite;
 /**
  * 提供 {@link Layer} 一個獨立的 interface 以操作實際的 {@link Sprite}。
  */
+//實作邏輯請參考 LTextSprite
 interface LSprite {
 	void setLayer(Layer layer);
 

--- a/src/main/java/us/dontcareabout/gxt/client/draw/LSprite.java
+++ b/src/main/java/us/dontcareabout/gxt/client/draw/LSprite.java
@@ -1,0 +1,40 @@
+package us.dontcareabout.gxt.client.draw;
+
+import com.sencha.gxt.chart.client.draw.sprite.Sprite;
+
+/**
+ * 提供 {@link Layer} 一個獨立的 interface 以操作實際的 {@link Sprite}。
+ */
+interface LSprite {
+	void setLayer(Layer layer);
+
+	/**
+	 * 設定相對於 Layer 原點的 X 值。
+	 */
+	void setLX(double value);
+
+	/**
+	 * 設定相對於 Layer 原點的 Y 值。
+	 */
+	void setLY(double value);
+
+	/**
+	 * 設定相對於 Layer 的 zIndex 值。
+	 */
+	void setLZIndex(int value);
+
+	/**
+	 * 取得相對於 Layer 原點的 X 值。
+	 */
+	double getLX();
+
+	/**
+	 * 取得相對於 Layer 原點的 Y 值。
+	 */
+	double getLY();
+
+	/**
+	 * 取得相對於 Layer 的 zIndex 值。
+	 */
+	int getLZIndex();
+}

--- a/src/main/java/us/dontcareabout/gxt/client/draw/LTextSprite.java
+++ b/src/main/java/us/dontcareabout/gxt/client/draw/LTextSprite.java
@@ -1,0 +1,97 @@
+package us.dontcareabout.gxt.client.draw;
+
+import com.sencha.gxt.chart.client.draw.sprite.TextSprite;
+
+/**
+ * {@link Layer} 專用的 {@link TextSprite}。
+ */
+//因為邏輯都一樣，所以註解只寫 x 那一組。
+public class LTextSprite extends TextSprite implements LSprite{
+	private Parameter parameter = new Parameter();
+	private Layer layer;
+
+	@Override
+	public void setLayer(Layer layer) {
+		this.layer = layer;
+	}
+
+	@Override
+	public void setX(double value) {
+		//不讓 caller 有自己決定實際 x 值的能力
+		//所以透過 parameter.lock 來把關
+		//有可能在 parent 的 constructor 當中就呼叫過（setZIndex() 必定會）
+		//所以必須先阻攔 parameter 還沒有 instance 的狀況
+		if (parameter != null && parameter.lock) {
+			throw new UnsupportedOperationException("Use setLX() instead.");
+		}
+
+		super.setX(value);
+	}
+
+	@Override
+	public void setLX(double value) {
+		parameter.x = value;
+
+		//允許 caller 在還沒作 Layer.add() 前就設定 setLX()
+		if (layer == null) { return; }
+
+		parameter.lock = true;
+		setX(layer.getX() + parameter.x);
+		parameter.lock = false;
+	}
+
+	@Override
+	public double getLX() {
+		return parameter.x;
+	}
+
+	@Override
+	public void setY(double value) {
+		if (parameter != null && parameter.lock) {
+			throw new UnsupportedOperationException("Use setLY() instead.");
+		}
+
+		super.setY(value);
+	}
+
+	@Override
+	public void setLY(double value) {
+		parameter.y = value;
+
+		if (layer == null) { return; }
+
+		parameter.lock = false;
+		setY(layer.getY() + parameter.y);
+		parameter.lock = true;
+	}
+
+	@Override
+	public double getLY() {
+		return parameter.y;
+	}
+
+	@Override
+	public void setZIndex(int zIndex) {
+		if (parameter != null && parameter.lock) {
+			throw new UnsupportedOperationException("Use setLZIndex() instead.");
+		}
+
+		super.setZIndex(zIndex);
+	}
+
+	@Override
+	public void setLZIndex(int value) {
+		parameter.zIndex = value;
+
+		if (layer == null) { return; }
+
+		parameter.lock = false;
+		setZIndex(layer.getZIndex() + parameter.zIndex);
+		parameter.lock = true;
+	}
+
+	@Override
+	public int getLZIndex() {
+		return parameter.zIndex;
+	}
+}

--- a/src/main/java/us/dontcareabout/gxt/client/draw/Layer.java
+++ b/src/main/java/us/dontcareabout/gxt/client/draw/Layer.java
@@ -1,0 +1,95 @@
+package us.dontcareabout.gxt.client.draw;
+
+import java.util.ArrayList;
+
+import com.sencha.gxt.chart.client.draw.DrawComponent;
+import com.sencha.gxt.chart.client.draw.sprite.Sprite;
+
+/**
+ * 可以一次調整一組 {@link LSprite}（實際上還是 {@link Sprite}）的 X、Y、ZIndex 的 class。
+ * <p>
+ * caller 透過 {@link #add(LSprite)} 將 sprite 納入此 Layer 的管轄範圍，
+ * 然後用 {@link #deploy(DrawComponent)} 將此 Layer 所管轄的 sprite
+ * 實際加到 {@link DrawComponent} 上。
+ * 此後，只要呼叫對應 setter（例如 {@link #setX(double)}），
+ * 就會將所管轄的 sprite 作對應的調整。
+ * <p>
+ * <b>注意：{@link Layer} 不負責處理 redraw 時機</b>
+ */
+public class Layer {
+	private ArrayList<LSprite> sprites = new ArrayList<>();
+
+	private double x;
+	private double y;
+	private int zIndex = 0;
+
+	public Layer() {
+		this(0, 0);
+	}
+
+	public Layer(double x, double y) {
+		this.x = x;
+		this.y = y;
+	}
+
+	public void add(LSprite sprite) {
+		sprites.add(sprite);
+		sprite.setLayer(this);
+		sprite.setLX(sprite.getLX());
+		sprite.setLY(sprite.getLY());
+		sprite.setLZIndex(sprite.getLZIndex());
+	}
+
+	public void deploy(DrawComponent component) {
+		for (LSprite sprite : sprites) {
+			Sprite s = (Sprite)sprite;
+
+			//避免 caller 重複呼叫，所以用 getComponent() 是否為 null 來判斷是否加過了
+			if (s.getComponent() != null) { continue; }
+
+			component.addSprite(s);
+		}
+	}
+
+	public void setX(double value) {
+		if (value == x) { return; }
+
+		x = value;
+
+		for (LSprite sprite : sprites) {
+			sprite.setLX(sprite.getLX());
+		}
+	}
+
+	public void setY(double value) {
+		if (value == y) { return; }
+
+		y = value;
+
+		for (LSprite sprite : sprites) {
+			sprite.setLY(sprite.getLY());
+		}
+	}
+
+	public void setZIndex(int value) {
+		if (value == zIndex) { return; }
+
+		zIndex = value;
+
+		for (LSprite sprite : sprites) {
+			sprite.setLZIndex(sprite.getLZIndex());
+		}
+	}
+
+	public double getX() {
+		return x;
+	}
+
+	public double getY() {
+		return y;
+	}
+
+	public int getZIndex() {
+		return zIndex;
+	}
+}

--- a/src/main/java/us/dontcareabout/gxt/client/draw/Parameter.java
+++ b/src/main/java/us/dontcareabout/gxt/client/draw/Parameter.java
@@ -1,0 +1,31 @@
+package us.dontcareabout.gxt.client.draw;
+
+import com.sencha.gxt.chart.client.draw.DrawComponent;
+
+/**
+ * {@link LSprite} 共用的參數 set。
+ */
+class Parameter {
+	/**
+	 * 讓原本 sprite 的 setX() 等 method 無法被呼叫的 flag。
+	 */
+	boolean lock = true;
+
+	/**
+	 * 相對於 {@link Layer} 的 x 值，
+	 * 也就是說 x + {@link Layer#getX()} 才是真正在 {@link DrawComponent} 上的值。
+	 */
+	double x;
+
+	/**
+	 * 相對於 {@link Layer} 的 y 值，
+	 * 也就是說 y + {@link Layer#getY()} 才是真正在 {@link DrawComponent} 上的值。
+	 */
+	double y;
+
+	/**
+	 * 相對於 {@link Layer} 的 zIndex 值，
+	 * 也就是說 zIndex + {@link Layer#getZIndex()()} 才是真正在 {@link DrawComponent} 上的值。
+	 */
+	int zIndex;
+}


### PR DESCRIPTION
### 前情提要 ###

`DrawComponent` 大抵上可看作 GXT 版的 canvas（如果要知道進一步細節可以看[這裡](https://gwt.dontcareabout.us/GXT/DrawComponent.html)，不過光看前情提要應該就夠了）。

要在上頭畫圖形，就是要加一堆 `Sprite`（`DrawComponent.add(Sprite)`），例如 `TextSprite` 就是在 canvas 上頭打出一串字。所以 `Sprite` 除了位置（x，y，zIndex）之外還會依照不同種類有不同 attribute，例如 `TextSprite` 就會有設定字型、字體大小....


### Layer 要解決的問題 ###

一言以蔽之：`DrawComponent` 並沒有（繪圖軟體當中）layer 的概念。

如果畫面上有一組 sprite 們的彼此的相對位置是固定的，而在 `DrawComponent` 上的位子會變動，你必須自己抓出那些 sprite 然後一個一個設定。

![example](https://user-images.githubusercontent.com/1705394/32638682-6a999c50-c5fb-11e7-8af9-276504aa1712.jpg)

在上面這個例子當中，右邊的「5 天」跟「50%」分別都由 3 個 sprite 組成（底色一個、數字一個、右下角文字一個）。如果要把它們往左移動（例如因為 DrawComponent 變窄，而這兩塊仍然希望靠右），就得這樣

```Java
//width 是新的 DrawComponent 寬度
reciprocal.setX(width - reciprocalWidth - 20);    //因為座標是相對 DrawComponent，所以得自己計算間距之類的雜事
reciprocalDay.setX(width - FOOTER_SIZE - 20);
reciprocalBG.setX(width - reciprocalBG.getWidth() - 5);

progress.setX(width - reciprocalBG.getWidth() - progressWidth - 25);
progressBG.setX(width - reciprocalBG.getWidth() - progressBG.getWidth() - 10);
progressRatio.setX(width - reciprocalBG.getWidth() - 45);
```

如果有 layer 概念，那麼只要調整 layer，layer 上的 sprite 就會跟著動：

```Java
reciprocalLayer.setX(reciprocalLayer.getX() + width - oldWidth);
progressLayer.setX(progressLayer.getX() + width - oldWidth);
```


### 設計上的問題 & 預防性答辯 ###

1. 其實不是所有 `Sprite` 都有 `setX()`、`setY()`，像 `CircleSprite` 就是 `setCenterX()`
1. 希望 Layer 的程式碼可以單純一點，不用針對各種 sprite 去判斷 instanceof（GXT 底層的實作的確就是這樣 😱 ）來區分是要呼叫 `setX()` 還是 `setCenterX()`，而是各個 sprite 自己決定實作方式。所以勢必要弄出一個給 Layer 呼叫的 interface（就是 `LSprite`）
1. 除了上一點，還有這些理由得採取「is-a」的作法來繼承出一堆 Layer 版的 Sprite：
   * 無法改動 GXT 的 code
   * 還是有其他 attribute 得設定 / 操作，那是 Layer 不關心的事情（例如字型大小），所以如果要 has-a 那只能搞出一堆 delegate method，但是好像看不出什麼好處。
1. 最後，因為 x、y、zIndex 已經給 Layer 負責，所以希望 caller 無法自己去變動實際的值。要嘛去改變 Layer 的值、要嘛去改變 sprite 在 Layer 上頭的相對值（也就是 `setLX()`）


大概是這樣...... [死]