### PR TITLE
增加 LayerContainer

### DIFF
--- a/src/main/java/us/dontcareabout/gxt/client/draw/LCircleSprite.java
+++ b/src/main/java/us/dontcareabout/gxt/client/draw/LCircleSprite.java
@@ -1,0 +1,88 @@
+package us.dontcareabout.gxt.client.draw;
+
+import com.sencha.gxt.chart.client.draw.sprite.CircleSprite;
+
+public class LCircleSprite extends CircleSprite implements LSprite {
+	private Parameter parameter = new Parameter();
+	private Layer layer;
+
+	@Override
+	public void setLayer(Layer layer) {
+		this.layer = layer;
+	}
+
+	@Override
+	public void setCenterX(double value) {
+		if (parameter != null && parameter.lock) {
+			throw new UnsupportedOperationException("Use setLX() instead.");
+		}
+
+		super.setCenterX(value);
+	}
+
+	@Override
+	public void setLX(double value) {
+		parameter.x = value;
+
+		if (layer == null) { return; }
+
+		parameter.lock = false;
+		setCenterX(layer.getX() + parameter.x);
+		parameter.lock = true;
+	}
+
+	@Override
+	public double getLX() {
+		return parameter.x;
+	}
+
+	@Override
+	public void setCenterY(double value) {
+		if (parameter != null && parameter.lock) {
+			throw new UnsupportedOperationException("Use setLY() instead.");
+		}
+
+		super.setCenterY(value);
+	}
+
+	@Override
+	public void setLY(double value) {
+		parameter.y = value;
+
+		if (layer == null) { return; }
+
+		parameter.lock = false;
+		setCenterY(layer.getY() + parameter.y);
+		parameter.lock = true;
+	}
+
+	@Override
+	public double getLY() {
+		return parameter.y;
+	}
+
+	@Override
+	public void setZIndex(int zIndex) {
+		if (parameter != null && parameter.lock) {
+			throw new UnsupportedOperationException("Use setLZIndex() instead.");
+		}
+
+		super.setZIndex(zIndex);
+	}
+
+	@Override
+	public void setLZIndex(int value) {
+		parameter.zIndex = value;
+
+		if (layer == null) { return; }
+
+		parameter.lock = false;
+		setZIndex(layer.getZIndex() + parameter.zIndex);
+		parameter.lock = true;
+	}
+
+	@Override
+	public int getLZIndex() {
+		return parameter.zIndex;
+	}
+}

--- a/src/main/java/us/dontcareabout/gxt/client/draw/LEllipseSprite.java
+++ b/src/main/java/us/dontcareabout/gxt/client/draw/LEllipseSprite.java
@@ -1,0 +1,88 @@
+package us.dontcareabout.gxt.client.draw;
+
+import com.sencha.gxt.chart.client.draw.sprite.EllipseSprite;
+
+public class LEllipseSprite extends EllipseSprite implements LSprite {
+	private Parameter parameter = new Parameter();
+	private Layer layer;
+
+	@Override
+	public void setLayer(Layer layer) {
+		this.layer = layer;
+	}
+
+	@Override
+	public void setCenterX(double value) {
+		if (parameter != null && parameter.lock) {
+			throw new UnsupportedOperationException("Use setLX() instead.");
+		}
+
+		super.setCenterX(value);
+	}
+
+	@Override
+	public void setLX(double value) {
+		parameter.x = value;
+
+		if (layer == null) { return; }
+
+		parameter.lock = false;
+		setCenterX(layer.getX() + parameter.x);
+		parameter.lock = true;
+	}
+
+	@Override
+	public double getLX() {
+		return parameter.x;
+	}
+
+	@Override
+	public void setCenterY(double value) {
+		if (parameter != null && parameter.lock) {
+			throw new UnsupportedOperationException("Use setLY() instead.");
+		}
+
+		super.setCenterY(value);
+	}
+
+	@Override
+	public void setLY(double value) {
+		parameter.y = value;
+
+		if (layer == null) { return; }
+
+		parameter.lock = false;
+		setCenterY(layer.getY() + parameter.y);
+		parameter.lock = true;
+	}
+
+	@Override
+	public double getLY() {
+		return parameter.y;
+	}
+
+	@Override
+	public void setZIndex(int zIndex) {
+		if (parameter != null && parameter.lock) {
+			throw new UnsupportedOperationException("Use setLZIndex() instead.");
+		}
+
+		super.setZIndex(zIndex);
+	}
+
+	@Override
+	public void setLZIndex(int value) {
+		parameter.zIndex = value;
+
+		if (layer == null) { return; }
+
+		parameter.lock = false;
+		setZIndex(layer.getZIndex() + parameter.zIndex);
+		parameter.lock = true;
+	}
+
+	@Override
+	public int getLZIndex() {
+		return parameter.zIndex;
+	}
+}

--- a/src/main/java/us/dontcareabout/gxt/client/draw/LImageSprite.java
+++ b/src/main/java/us/dontcareabout/gxt/client/draw/LImageSprite.java
@@ -1,0 +1,88 @@
+package us.dontcareabout.gxt.client.draw;
+
+import com.sencha.gxt.chart.client.draw.sprite.ImageSprite;
+
+public class LImageSprite extends ImageSprite implements LSprite {
+	private Parameter parameter = new Parameter();
+	private Layer layer;
+
+	@Override
+	public void setLayer(Layer layer) {
+		this.layer = layer;
+	}
+
+	@Override
+	public void setX(double value) {
+		if (parameter != null && parameter.lock) {
+			throw new UnsupportedOperationException("Use setLX() instead.");
+		}
+
+		super.setX(value);
+	}
+
+	@Override
+	public void setLX(double value) {
+		parameter.x = value;
+
+		if (layer == null) { return; }
+
+		parameter.lock = false;
+		setX(layer.getX() + parameter.x);
+		parameter.lock = true;
+	}
+
+	@Override
+	public double getLX() {
+		return parameter.x;
+	}
+
+	@Override
+	public void setY(double value) {
+		if (parameter != null && parameter.lock) {
+			throw new UnsupportedOperationException("Use setLY() instead.");
+		}
+
+		super.setY(value);
+	}
+
+	@Override
+	public void setLY(double value) {
+		parameter.y = value;
+
+		if (layer == null) { return; }
+
+		parameter.lock = false;
+		setY(layer.getY() + parameter.y);
+		parameter.lock = true;
+	}
+
+	@Override
+	public double getLY() {
+		return parameter.y;
+	}
+
+	@Override
+	public void setZIndex(int zIndex) {
+		if (parameter != null && parameter.lock) {
+			throw new UnsupportedOperationException("Use setLZIndex() instead.");
+		}
+
+		super.setZIndex(zIndex);
+	}
+
+	@Override
+	public void setLZIndex(int value) {
+		parameter.zIndex = value;
+
+		if (layer == null) { return; }
+
+		parameter.lock = false;
+		setZIndex(layer.getZIndex() + parameter.zIndex);
+		parameter.lock = true;
+	}
+
+	@Override
+	public int getLZIndex() {
+		return parameter.zIndex;
+	}
+}

--- a/src/main/java/us/dontcareabout/gxt/client/draw/LRectangleSprite.java
+++ b/src/main/java/us/dontcareabout/gxt/client/draw/LRectangleSprite.java
@@ -1,0 +1,88 @@
+package us.dontcareabout.gxt.client.draw;
+
+import com.sencha.gxt.chart.client.draw.sprite.RectangleSprite;
+
+public class LRectangleSprite extends RectangleSprite implements LSprite {
+	private Parameter parameter = new Parameter();
+	private Layer layer;
+
+	@Override
+	public void setLayer(Layer layer) {
+		this.layer = layer;
+	}
+
+	@Override
+	public void setX(double value) {
+		if (parameter != null && parameter.lock) {
+			throw new UnsupportedOperationException("Use setLX() instead.");
+		}
+
+		super.setX(value);
+	}
+
+	@Override
+	public void setLX(double value) {
+		parameter.x = value;
+
+		if (layer == null) { return; }
+
+		parameter.lock = false;
+		setX(layer.getX() + parameter.x);
+		parameter.lock = true;
+	}
+
+	@Override
+	public double getLX() {
+		return parameter.x;
+	}
+
+	@Override
+	public void setY(double value) {
+		if (parameter != null && parameter.lock) {
+			throw new UnsupportedOperationException("Use setLY() instead.");
+		}
+
+		super.setY(value);
+	}
+
+	@Override
+	public void setLY(double value) {
+		parameter.y = value;
+
+		if (layer == null) { return; }
+
+		parameter.lock = false;
+		setY(layer.getY() + parameter.y);
+		parameter.lock = true;
+	}
+
+	@Override
+	public double getLY() {
+		return parameter.y;
+	}
+
+	@Override
+	public void setZIndex(int zIndex) {
+		if (parameter != null && parameter.lock) {
+			throw new UnsupportedOperationException("Use setLZIndex() instead.");
+		}
+
+		super.setZIndex(zIndex);
+	}
+
+	@Override
+	public void setLZIndex(int value) {
+		parameter.zIndex = value;
+
+		if (layer == null) { return; }
+
+		parameter.lock = false;
+		setZIndex(layer.getZIndex() + parameter.zIndex);
+		parameter.lock = true;
+	}
+
+	@Override
+	public int getLZIndex() {
+		return parameter.zIndex;
+	}
+}

--- a/src/main/java/us/dontcareabout/gxt/client/draw/LTextSprite.java
+++ b/src/main/java/us/dontcareabout/gxt/client/draw/LTextSprite.java
@@ -35,9 +35,9 @@ public class LTextSprite extends TextSprite implements LSprite{
 		//允許 caller 在還沒作 Layer.add() 前就設定 setLX()
 		if (layer == null) { return; }
 
-		parameter.lock = true;
-		setX(layer.getX() + parameter.x);
 		parameter.lock = false;
+		setX(layer.getX() + parameter.x);
+		parameter.lock = true;
 	}
 
 	@Override

--- a/src/main/java/us/dontcareabout/gxt/client/draw/Layer.java
+++ b/src/main/java/us/dontcareabout/gxt/client/draw/Layer.java
@@ -72,6 +72,29 @@ public class Layer {
 		}
 	}
 
+	/**
+	 * 判斷 member sprite 中是否包含指定的 sprite。
+	 * <p>
+	 * 若指定的 sprite 是 member sprite（{@link LayerSprite}）的 member sprite，
+	 * 也會回傳 true。
+	 */
+	public boolean hasSprite(Sprite target) {
+		//無法預期 DFS / BFS 哪個比較有效率，所以選擇程式碼比較簡單的 DFS
+		for (LSprite sprite : sprites) {
+			if (sprite instanceof LayerSprite) {
+				if (((LayerSprite)sprite).hasSprite(target)) {
+					return true;
+				}
+			} else {
+				if (sprite == target) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
 	public void deploy(DrawComponent component) {
 		this.drawComponent = component;
 

--- a/src/main/java/us/dontcareabout/gxt/client/draw/Layer.java
+++ b/src/main/java/us/dontcareabout/gxt/client/draw/Layer.java
@@ -2,8 +2,22 @@ package us.dontcareabout.gxt.client.draw;
 
 import java.util.ArrayList;
 
+import com.google.gwt.event.shared.HandlerManager;
+import com.google.gwt.event.shared.HandlerRegistration;
 import com.sencha.gxt.chart.client.draw.DrawComponent;
 import com.sencha.gxt.chart.client.draw.sprite.Sprite;
+import com.sencha.gxt.chart.client.draw.sprite.SpriteOutEvent;
+import com.sencha.gxt.chart.client.draw.sprite.SpriteOutEvent.HasSpriteOutHandlers;
+import com.sencha.gxt.chart.client.draw.sprite.SpriteOutEvent.SpriteOutHandler;
+import com.sencha.gxt.chart.client.draw.sprite.SpriteOverEvent;
+import com.sencha.gxt.chart.client.draw.sprite.SpriteOverEvent.HasSpriteOverHandlers;
+import com.sencha.gxt.chart.client.draw.sprite.SpriteOverEvent.SpriteOverHandler;
+import com.sencha.gxt.chart.client.draw.sprite.SpriteSelectionEvent;
+import com.sencha.gxt.chart.client.draw.sprite.SpriteSelectionEvent.HasSpriteSelectionHandlers;
+import com.sencha.gxt.chart.client.draw.sprite.SpriteSelectionEvent.SpriteSelectionHandler;
+import com.sencha.gxt.chart.client.draw.sprite.SpriteUpEvent;
+import com.sencha.gxt.chart.client.draw.sprite.SpriteUpEvent.HasSpriteUpHandlers;
+import com.sencha.gxt.chart.client.draw.sprite.SpriteUpEvent.SpriteUpHandler;
 
 /**
  * 可以一次調整一組 {@link LSprite}（實際上還是 {@link Sprite}）的 X、Y、ZIndex 的 class。
@@ -15,7 +29,11 @@ import com.sencha.gxt.chart.client.draw.sprite.Sprite;
  * <p>
  * <b>注意：{@link Layer} 不負責處理 redraw 時機</b>
  */
-public class Layer {
+public class Layer
+	implements HasSpriteOutHandlers, HasSpriteOverHandlers, HasSpriteSelectionHandlers, HasSpriteUpHandlers {
+
+	private HandlerManager handlerManager;
+
 	private ArrayList<LSprite> sprites = new ArrayList<>();
 
 	private double x;
@@ -170,5 +188,36 @@ public class Layer {
 
 	public int getZIndex() {
 		return zIndex;
+	}
+
+	@Override
+	public HandlerRegistration addSpriteOutHandler(SpriteOutHandler handler) {
+		return ensureHandler().addHandler(SpriteOutEvent.getType(), handler);
+	}
+
+	@Override
+	public HandlerRegistration addSpriteOverHandler(SpriteOverHandler handler) {
+		return ensureHandler().addHandler(SpriteOverEvent.getType(), handler);
+	}
+
+	@Override
+	public HandlerRegistration addSpriteSelectionHandler(SpriteSelectionHandler handler) {
+		return ensureHandler().addHandler(SpriteSelectionEvent.getType(), handler);
+	}
+
+	@Override
+	public HandlerRegistration addSpriteUpHandler(SpriteUpHandler handler) {
+		return ensureHandler().addHandler(SpriteUpEvent.getType(), handler);
+	}
+
+	//比照 DrawComponent 用 protected
+	//其實 GWT / GXT 對 HandlerManager 的建立寫法有點混亂... ＝＝"
+	//（參見神奇的 ComponentHelper.ensureHandlers()）
+	protected HandlerManager ensureHandler() {
+		if (handlerManager == null) {
+			handlerManager = new HandlerManager(this);
+		}
+
+		return handlerManager;
 	}
 }

--- a/src/main/java/us/dontcareabout/gxt/client/draw/Layer.java
+++ b/src/main/java/us/dontcareabout/gxt/client/draw/Layer.java
@@ -42,6 +42,12 @@ public class Layer {
 
 	public void deploy(DrawComponent component) {
 		for (LSprite sprite : sprites) {
+			if (sprite instanceof LayerSprite) {
+				Layer layer = (Layer) sprite;
+				layer.deploy(component);
+				continue;
+			}
+
 			Sprite s = (Sprite)sprite;
 
 			//避免 caller 重複呼叫，所以用 getComponent() 是否為 null 來判斷是否加過了

--- a/src/main/java/us/dontcareabout/gxt/client/draw/Layer.java
+++ b/src/main/java/us/dontcareabout/gxt/client/draw/Layer.java
@@ -8,11 +8,10 @@ import com.sencha.gxt.chart.client.draw.sprite.Sprite;
 /**
  * 可以一次調整一組 {@link LSprite}（實際上還是 {@link Sprite}）的 X、Y、ZIndex 的 class。
  * <p>
- * caller 透過 {@link #add(LSprite)} 將 sprite 納入此 Layer 的管轄範圍，
- * 然後用 {@link #deploy(DrawComponent)} 將此 Layer 所管轄的 sprite
- * 實際加到 {@link DrawComponent} 上。
+ * caller 透過 {@link #add(LSprite)} 將 sprite 變成 Layer 的 member sprite，
+ * 然後用 {@link #deploy(DrawComponent)} 將 member sprite 實際加到 {@link DrawComponent} 上。
  * 此後，只要呼叫對應 setter（例如 {@link #setX(double)}），
- * 就會將所管轄的 sprite 作對應的調整。
+ * 就會將所有 member sprite 作對應的調整。
  * <p>
  * <b>注意：{@link Layer} 不負責處理 redraw 時機</b>
  */

--- a/src/main/java/us/dontcareabout/gxt/client/draw/Layer.java
+++ b/src/main/java/us/dontcareabout/gxt/client/draw/Layer.java
@@ -23,6 +23,8 @@ public class Layer {
 	private double y;
 	private int zIndex = 0;
 
+	private DrawComponent drawComponent;
+
 	public Layer() {
 		this(0, 0);
 	}
@@ -40,7 +42,40 @@ public class Layer {
 		sprite.setLZIndex(sprite.getLZIndex());
 	}
 
+	/**
+	 * 將指定的 sprite 從 {@link Layer} 上移除，同時也會自 {@link DrawComponent} 上移除。
+	 * <p>
+	 * 若指定的 sprite 是在 {@link LayerSprite} 之上（或是 {@link LayerSprite} 上的 {@link LayerSprite}），
+	 * remove() 依然可以將其移除。
+	 *
+	 * @see #undeploy()
+	 */
+	public void remove(LSprite target) {
+		for (LSprite sprite : sprites) {
+			if (sprite == target) {
+				if (sprite instanceof LayerSprite) {
+					((Layer)sprite).undeploy();
+					sprites.remove(sprite);
+				} else {
+					sprites.remove(sprite);
+					drawComponent.remove((Sprite)sprite);
+				}
+
+				return;
+			}
+		}
+
+		//第一層找不到，就看看有沒有 LayerSprite 然後往上找
+		for (LSprite sprite : sprites) {
+			if (sprite instanceof LayerSprite) {
+				((Layer)sprite).remove(target);
+			}
+		}
+	}
+
 	public void deploy(DrawComponent component) {
+		this.drawComponent = component;
+
 		for (LSprite sprite : sprites) {
 			if (sprite instanceof LayerSprite) {
 				Layer layer = (Layer) sprite;
@@ -54,6 +89,22 @@ public class Layer {
 			if (s.getComponent() != null) { continue; }
 
 			component.addSprite(s);
+		}
+	}
+
+	/**
+	 * 將 {@link Layer}（包含所擁有的 {@link LSprite}）從 {@link DrawComponent} 上移除。
+	 * <p>
+	 * <b>undeploy() 並不會影響 {@link Layer} 原本的 {@link LSprite} 結構</b>。
+	 * 如果要將 {@link LSprite} 從 {@link Layer} 中移除，請使用 {@link #remove(LSprite)}。
+	 */
+	public void undeploy() {
+		for (LSprite sprite : sprites) {
+			if (sprite instanceof LayerSprite) {
+				((Layer)sprite).undeploy();
+			} else {
+				drawComponent.remove((Sprite)sprite);
+			}
 		}
 	}
 

--- a/src/main/java/us/dontcareabout/gxt/client/draw/LayerContainer.java
+++ b/src/main/java/us/dontcareabout/gxt/client/draw/LayerContainer.java
@@ -1,0 +1,99 @@
+package us.dontcareabout.gxt.client.draw;
+
+import java.util.ArrayList;
+
+import com.google.gwt.event.shared.GwtEvent;
+import com.sencha.gxt.chart.client.draw.DrawComponent;
+import com.sencha.gxt.chart.client.draw.sprite.Sprite;
+import com.sencha.gxt.chart.client.draw.sprite.SpriteHandler;
+import com.sencha.gxt.chart.client.draw.sprite.SpriteOutEvent;
+import com.sencha.gxt.chart.client.draw.sprite.SpriteOverEvent;
+import com.sencha.gxt.chart.client.draw.sprite.SpriteSelectionEvent;
+import com.sencha.gxt.chart.client.draw.sprite.SpriteSelectionEvent.SpriteSelectionHandler;
+import com.sencha.gxt.chart.client.draw.sprite.SpriteUpEvent;
+
+/**
+ * {@link DrawComponent} 的延伸，解決 {@link DrawComponent} 處理 sprite handler 的缺陷。
+ * <p>
+ * 以「點擊 sprite」為例，
+ * 原本 GXT 的設計是使用 {@link DrawComponent#addSpriteSelectionHandler(SpriteSelectionHandler)}，
+ * 從 {@link SpriteSelectionEvent#getSprite()} 取得觸發的 sprite，然後才能作對應的處理。
+ * 如果會觸發 event 的 sprite 數量很多、那麼 handler 實作程式碼就會糾結一團十分混亂。
+ * <p>
+ * 導入 {@link Layer} 後，handler 實作改為 {@link Layer#addSpriteSelectionHandler(SpriteSelectionHandler)} 負責，
+ * {@link LayerContainer} 只負責將 event 導向至擁有觸發 event 的 sprite 的 {@link Layer}。
+ * <p>
+ * 參考下圖
+ * <pre>
+ * +----------------------------+
+ * | LayerContainer             |
+ * |  +-----------------------+ |
+ * |  | layer A               | |
+ * |  |  +------------------+ | |
+ * |  |  | layer B          | | |
+ * |  |  +------------------+ | |
+ * |  +-----------------------+ |
+ * +----------------------------+
+ * </pre>
+ * 假設觸發 selection event 的 sprite 在 layer B 上，
+ * layer B 有掛載對應 handler。會有下列幾種狀況：
+ * <ul>
+ * 	<li>
+ * 		layer A <b>沒有</b>掛載 handler：觸發 layer B 的 handler
+ * 	</li>
+ * 	<li>
+ * 		layer A <b>有</b>掛載 handler，且 {@link Layer#isStopPropagation()} 為 true：
+ * 		只觸發 layer A 的 handler。
+ * 	</li>
+ * 	<li>
+ * 		layer A <b>有</b>掛載 handler，且 {@link Layer#isStopPropagation()} 為 false：
+ * 		先觸發 layer A 的 handler，然後觸發 layer B 的 handler。
+ * 	</li>
+ * </ul>
+ */
+public class LayerContainer extends DrawComponent {
+	private ArrayList<Layer> layers = new ArrayList<>();
+
+	public LayerContainer() {
+		this(500, 500);
+	}
+
+	public LayerContainer(int w, int h) {
+		super(w, h);
+
+		addSpriteHandler(new SpriteHandler() {
+			@Override
+			public void onSpriteSelect(SpriteSelectionEvent event) {
+				handleEvent(event, event.getSprite());
+			}
+
+			@Override
+			public void onSpriteLeave(SpriteOutEvent event) {
+				handleEvent(event, event.getSprite());
+			}
+
+			@Override
+			public void onSpriteOver(SpriteOverEvent event) {
+				handleEvent(event, event.getSprite());
+			}
+
+			@Override
+			public void onSpriteUp(SpriteUpEvent event) {
+				handleEvent(event, event.getSprite());
+			}
+		});
+	}
+
+	public void addLayer(Layer layer) {
+		layers.add(layer);
+		layer.deploy(this);
+	}
+
+	private void handleEvent(GwtEvent<?> event, Sprite sprite) {
+		for (Layer layer : layers) {
+			if (layer.hasSprite(sprite)) {
+				layer.handleEvent(event, sprite);
+			}
+		}
+	}
+}

--- a/src/main/java/us/dontcareabout/gxt/client/draw/LayerSprite.java
+++ b/src/main/java/us/dontcareabout/gxt/client/draw/LayerSprite.java
@@ -1,12 +1,85 @@
 package us.dontcareabout.gxt.client.draw;
 
+import com.sencha.gxt.chart.client.draw.Color;
+import com.sencha.gxt.chart.client.draw.DrawComponent;
+
 /**
  * 特化版的 {@link Layer}。
  * 使其可以如 {@link LTextSprite} 等 sprite 一樣加在 {@link Layer} 上。
+ * <p>
+ * 有別於單純作為 sprite 集合的 {@link Layer}，
+ * LayerSprite 內建一個 {@link LRectangleSprite} 作為 background，
+ * 因此有實際的大小與可視範圍（但是並沒有防止 member sprite 超出範圍 XD）。
+ * caller 可在 {@link DrawComponent} onResize() 時
+ * 呼叫 {@link #onResize(double, double)} 來調整 LayerSprite 的大小，
+ * 並 override {@link #adjustMember()} 以實作各 member sprite 的對應調整。
+ * <p>
+ * 如果要調整 background 的樣式，請使用 setBg*() 系列 method，
+ * 例如 {@link #setBgRadius(double)}。
  */
 public class LayerSprite extends Layer implements LSprite {
 	private Parameter parameter = new Parameter();
 	private Layer layer;
+	private LRectangleSprite bg = new LRectangleSprite();
+
+	public LayerSprite() {
+		this(0, 0);
+	}
+
+	public LayerSprite(double x, double y) {
+		super(x, y);
+		add(bg);
+
+		bg.setFill(Color.NONE);
+	}
+
+	public final void onResize(double width, double height) {
+		if (width < 0 || height < 0) { return; }
+
+		setWidth(width);
+		setHeight(height);
+		adjustMember();
+	}
+
+	public void setWidth(double width) {
+		bg.setWidth(width);
+	}
+
+	public double getWidth() {
+		return bg.getWidth();
+	}
+
+	public void setHeight(double height) {
+		bg.setHeight(height);
+	}
+
+	public double getHeight() {
+		return bg.getHeight();
+	}
+
+	public void setBgColor(Color color) {
+		bg.setFill(color);
+	}
+
+	public Color getBgColor() {
+		return bg.getFill();
+	}
+
+	public void setBgOpacity(double opacity) {
+		bg.setOpacity(opacity);
+	}
+
+	public double getBgOpacity() {
+		return bg.getOpacity();
+	}
+
+	public void setBgRadius(double radius) {
+		bg.setRadius(radius);
+	}
+
+	public double getBgRadius() {
+		return bg.getRadius();
+	}
 
 	@Override
 	public void setLayer(Layer layer) {
@@ -79,4 +152,9 @@ public class LayerSprite extends Layer implements LSprite {
 
 		super.setZIndex(value);
 	}
+
+	/**
+	 * 在 {@link #onResize(double, double)} 時提供 child class 調整 member sprite 的時機點。
+	 */
+	protected void adjustMember() {}
 }

--- a/src/main/java/us/dontcareabout/gxt/client/draw/LayerSprite.java
+++ b/src/main/java/us/dontcareabout/gxt/client/draw/LayerSprite.java
@@ -1,0 +1,91 @@
+package us.dontcareabout.gxt.client.draw;
+
+/**
+ * 特化版的 {@link Layer}。
+ * 使其可以如 {@link LTextSprite} 等 sprite 一樣加在 {@link Layer} 上。
+ */
+public class LayerSprite extends Layer implements LSprite {
+	private Parameter parameter = new Parameter();
+	private Layer layer;
+
+	@Override
+	public void setLayer(Layer layer) {
+		this.layer = layer;
+	}
+
+	@Override
+	public void setLX(double value) {
+		parameter.x = value;
+
+		if (layer == null) { return; }
+
+		parameter.lock = false;
+		setX(layer.getX() + parameter.x);
+		parameter.lock = true;
+	}
+
+	@Override
+	public void setLY(double value) {
+		parameter.y = value;
+
+		if (layer == null) { return; }
+
+		parameter.lock = false;
+		setY(layer.getY() + parameter.y);
+		parameter.lock = true;
+	}
+
+	@Override
+	public void setLZIndex(int value) {
+		parameter.zIndex = value;
+
+		if (layer == null) { return; }
+
+		parameter.lock = false;
+		setZIndex(layer.getZIndex() + parameter.zIndex);
+		parameter.lock = true;
+	}
+
+	@Override
+	public double getLX() {
+		return parameter.x;
+	}
+
+	@Override
+	public double getLY() {
+		return parameter.y;
+	}
+
+	@Override
+	public int getLZIndex() {
+		return parameter.zIndex;
+	}
+
+	@Override
+	public void setX(double value) {
+		//不會有 parent class 呼叫 setX() 的問題，所以只判斷 lock
+		if (parameter.lock) {
+			throw new UnsupportedOperationException("Use setLX() instead.");
+		}
+
+		super.setX(value);
+	}
+
+	@Override
+	public void setY(double value) {
+		if (parameter.lock) {
+			throw new UnsupportedOperationException("Use setLY() instead.");
+		}
+
+		super.setY(value);
+	}
+
+	@Override
+	public void setZIndex(int value) {
+		if (parameter.lock) {
+			throw new UnsupportedOperationException("Use setLZIndex() instead.");
+		}
+
+		super.setZIndex(value);
+	}
+}

--- a/src/main/java/us/dontcareabout/gxt/client/draw/LayerSprite.java
+++ b/src/main/java/us/dontcareabout/gxt/client/draw/LayerSprite.java
@@ -16,33 +16,24 @@ public class LayerSprite extends Layer implements LSprite {
 	@Override
 	public void setLX(double value) {
 		parameter.x = value;
-
-		if (layer == null) { return; }
-
 		parameter.lock = false;
-		setX(layer.getX() + parameter.x);
+		setX((layer == null ? 0 : layer.getX()) + parameter.x);
 		parameter.lock = true;
 	}
 
 	@Override
 	public void setLY(double value) {
 		parameter.y = value;
-
-		if (layer == null) { return; }
-
 		parameter.lock = false;
-		setY(layer.getY() + parameter.y);
+		setY((layer == null ? 0 : layer.getY()) + parameter.y);
 		parameter.lock = true;
 	}
 
 	@Override
 	public void setLZIndex(int value) {
 		parameter.zIndex = value;
-
-		if (layer == null) { return; }
-
 		parameter.lock = false;
-		setZIndex(layer.getZIndex() + parameter.zIndex);
+		setZIndex((layer == null ? 0 : layer.getZIndex()) + parameter.zIndex);
 		parameter.lock = true;
 	}
 


### PR DESCRIPTION
假設 `DrawComponent` 上有兩個 sprite：`foo` 跟 `bar`，希望按下這兩個 sprite 時能噴對應的字出來。以前得這麼寫：

```Java
class WTF extends DrawComponent {
	TextSprite foo, bar;    //細節略

	WTF() {
		addSpriteSelectionHandler(new SpriteSelectionHandler() {
			@Override
			public void onSpriteSelect(SpriteSelectionEvent event) {
				Sprite source = event.getSprite();
				if (source == foo) { Console.log("foo"); } }
				else if(source == bar} { Console.log(bar"); }
			}
		});
	}
}
```

當會觸發 event 的 sprite 一多，handler 的實作就會十分的... 有趣...... 😱 

因為有了 `Layer`，所以將 handler 的實作也轉移至 `Layer` 上。也就是說，「擁有 `foo` 的 `Layer` 要實作 `SpriteSelectionHandler` 而不是擠在 `DrawComponent` 裡頭」。這就是設計 `LayerContainer` 的目的。（當然，在上面的 case 當中，如果 `foo` 跟 `bar` 在同一個 layer 上是沒啥差別啦...... 💃 ）

也因為概念是「擁有 sprite 的 `Layer` 要實作」，再加上 `Layer` 上面可以有 `Layer`（`LayerSprite`），所以設計了 `Layer.setStopPropagation()` 的機制，來決定 event 是否要繼續轉交給 `Layer` 上的 `Layer` 來處理。以 JS / DOM 的說法，就是 capturing 式的 event handling，只不過 stop propagation 是由 field 來控制這樣。

（其他應該在 JavaDoc 都有說明，不夠請鞭）

ps. 請務必先將你的 master 更新至 581210b 這個 commit 再開始 merge / review。
